### PR TITLE
[IMP] Try to get the hardware code from the environment

### DIFF
--- a/odoo_sentinel/__init__.py
+++ b/odoo_sentinel/__init__.py
@@ -101,9 +101,14 @@ class Sentinel(object):
             self.hardware_code = ssh_data[0]
             self.scanner_check()
         except:
-            self.hardware_code = self._input_text(
-                _('Autoconfiguration failed !\nPlease enter terminal code'))
-            self.scanner_check()
+            try:
+                self.hardware_code = os.environ['ODOO_SENTINEL_CODE']
+                self.scanner_check()
+            except:
+                self.hardware_code = self._input_text(
+                    _('Autoconfiguration failed !\nPlease enter terminal code')
+                )
+                self.scanner_check()
 
         # Reinit colors with values configured in OpenERP
         self._reinit_colors()


### PR DESCRIPTION
This can be useful when the hardware is connected through SSH using an SSH key, for example.
With this, we are able to define the hardware code depending on the SSH key in the `~/.ssh/authorized_keys` of the system user.