### PR TITLE
[FIX] config file passed via '-c' argument ignored

### DIFF
--- a/odoo_sentinel/__init__.py
+++ b/odoo_sentinel/__init__.py
@@ -63,7 +63,8 @@ class Sentinel(object):
         """
         if options.profile in odoorpc.ODOO.list(rc_file=options.config_file):
             # Try to autodetect an OdooRPC configuration
-            self.connection = odoorpc.ODOO.load(options.profile)
+            self.connection = odoorpc.ODOO.load(options.profile,
+                                                rc_file=options.config_file)
         else:
             raise Exception(
                 'Profile "{options.profile}" not found in file '


### PR DESCRIPTION
The sentinel is always using the default ~/.odoorpcrc and ignoring the
one passed via '-c' parameter